### PR TITLE
Fix scan sync issue; channel closed before finished

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT			:= github.com/GlobalCyberAlliance/GCADMARCRiskScanner
 
-DEP				:= $(shell which dep)
-GO				:= $(shell which go)
+DEP				:= $(shell which dep 2>/dev/null)
+GO				:= $(shell which go 2>/dev/null)
 GO_BUILD_FLAGS	:=
 GO_BUILD		:= $(GO) build $(GO_BUILD_FLAGS)
 GO_TEST_FLAGS	:= -v -short
@@ -17,18 +17,30 @@ bin:
 	mkdir -p $@
 
 bin/%: $(shell find . -name "*.go" -type f)
+ifeq ("${GO}","")
+	$(error Cannot find "go" in your $$PATH)
+endif
 	$(GO_BUILD) -o $@ $(PROJECT)/cmd/$*
 
 deps: $(DEP)
+ifeq ("${DEP}","")
+	$(error Cannot find "dep" in your $$PATH)
+endif
 	$(DEP) ensure
 
 clean:
 	-rm -rf bin
 
 test:
+ifeq ("${GO}","")
+	$(error Cannot find "go" in your $$PATH)
+endif
 	$(GO_TEST) ./...
 
 bench:
+ifeq ("${GO}","")
+	$(error Cannot find "go" in your $$PATH)
+endif
 	$(GO_BENCH) ./...
 
 .PHONY: deps clean test bench

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ deps: $(DEP)
 clean:
 	-rm -rf bin
 
-test: $(GLIDE)
-	$(GO_TEST) $(shell $(GLIDE) novendor)
+test:
+	$(GO_TEST) ./...
 
-bench: $(GLIDE)
-	$(GO_BENCH) $(shell $(GLIDE) novendor)
+bench:
+	$(GO_BENCH) ./...
 
 .PHONY: deps clean test bench

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT			:= github.com/GlobalCyberAlliance/DMARC-Risk-Scanner
+PROJECT			:= github.com/GlobalCyberAlliance/GCADMARCRiskScanner
 
 DEP				:= $(shell which dep)
 GO				:= $(shell which go)


### PR DESCRIPTION
# Synopsis

In `scanner/scanner.go`, the `(*Scanner).scan()` function was not waiting for its goroutines to finish before returning.